### PR TITLE
Added WildcardChecker

### DIFF
--- a/Supertext.Base.Tests/Common/WildcardCheckerTest.cs
+++ b/Supertext.Base.Tests/Common/WildcardCheckerTest.cs
@@ -1,0 +1,117 @@
+﻿using FakeItEasy;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Supertext.Base.Common;
+
+namespace Supertext.Base.Tests.Common
+{
+    [TestClass]
+    public class WildcardCheckerTest
+    {
+        private WildcardChecker _testee;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _testee = new WildcardChecker();
+        }
+
+        [TestMethod]
+        public void IsPassing_WhenFilterIsValue_ShouldBeTrue()
+        {
+            // Arrange
+            const string testValue = "aValue";
+            const string testFilter = testValue;
+
+            // Act
+            var result = _testee.IsPassing(testFilter, testValue);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsPassing_WhenFilterHasStartAndEndOfValueWithoutWildcard_ShouldBeFalse()
+        {
+            // Arrange
+            const string testValue = "aValue";
+            const string testFilter = "alue";
+
+            // Act
+            var result = _testee.IsPassing(testFilter, testValue);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsPassing_WhenFilterHasStartAndEndOfValueWithWildcardInMiddle_ShouldBeTrue()
+        {
+            // Arrange
+            const string testValue = "aValue";
+            const string testFilter = "a*lue";
+
+            // Act
+            var result = _testee.IsPassing(testFilter, testValue);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsPassing_WhenFilterHasPartsOfValueWithMultipleWildcard_ShouldBeTrue()
+        {
+            // Arrange
+            const string testValue = "aValue";
+            const string testFilter = "*Va*e";
+
+            // Act
+            var result = _testee.IsPassing(testFilter, testValue);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsPassing_WhenFilterHasOnlyWildcard_ShouldBeTrue()
+        {
+            // Arrange
+            const string testValue = "aValue";
+            const string testFilter = "*";
+
+            // Act
+            var result = _testee.IsPassing(testFilter, testValue);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsPassing_WhenFilterHasMultipleOptionsAndOneOptionMatches_ShouldBeTrue()
+        {
+            // Arrange
+            const string testValue = "aValue";
+            const string testFilter = "some|o*her|*lue";
+
+            // Act
+            var result = _testee.IsPassing(testFilter, testValue);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsPassing_WhenFilterHasMultipleOptionsAndNoOptionMatches_ShouldBeFalse()
+        {
+            // Arrange
+            const string testValue = "aValue";
+            const string testFilter = "some|o*her|blue";
+
+            // Act
+            var result = _testee.IsPassing(testFilter, testValue);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/Supertext.Base/Common/IWildcardChecker.cs
+++ b/Supertext.Base/Common/IWildcardChecker.cs
@@ -1,0 +1,7 @@
+﻿namespace Supertext.Base.Common
+{
+    public interface IWildcardChecker
+    {
+        bool IsPassing(string filter, string value);
+    }
+}

--- a/Supertext.Base/Common/WildcardChecker.cs
+++ b/Supertext.Base/Common/WildcardChecker.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Supertext.Base.Common
+{
+    internal class WildcardChecker : IWildcardChecker
+    {
+        public bool IsPassing(string filter, string value)
+        {
+            var regex = ConvertToRegex(filter);
+
+            return regex.IsMatch(value);
+        }
+
+        private static Regex ConvertToRegex(string filter)
+        {
+            var wildcardReplacedFilter = filter.Replace("*", ".*");
+
+            return new Regex($"^{wildcardReplacedFilter}$");
+        }
+    }
+}

--- a/Supertext.Base/Modules/BaseModule.cs
+++ b/Supertext.Base/Modules/BaseModule.cs
@@ -1,7 +1,8 @@
-﻿using Autofac;
+﻿using System.Runtime.CompilerServices;
+using Autofac;
 using Supertext.Base.Common;
 using Supertext.Base.Factory;
-
+[assembly: InternalsVisibleTo("Supertext.Base.Tests")]
 namespace Supertext.Base.Modules
 {
     public class BaseModule : Module
@@ -9,6 +10,7 @@ namespace Supertext.Base.Modules
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<DateTimeProvider>().As<IDateTimeProvider>();
+            builder.RegisterType<WildcardChecker>().As<IWildcardChecker>();
 
             RegisterFactories(builder);
         }


### PR DESCRIPTION
I've added a wildcard checker which can be used to check if a value (string) passes through a filter that can contain wildcards (*) and multiple options (|).

**Example usages**
value: aSourceFile.json
filter: *.json
-> pass

value: aSourceFile.xml
filter: *.json
-> no pass

value: aSourceFile.json
filter: *Source*.json
-> pass

value: aTargetFile.json
filter: *Source*.json
-> no pass