### PR TITLE
Added SupertextConfiguration to Supertext.Base.

### DIFF
--- a/Supertext.Base.NetFramework.Configuration.Specs/ContainerSettingsRegisterTest.cs
+++ b/Supertext.Base.NetFramework.Configuration.Specs/ContainerSettingsRegisterTest.cs
@@ -24,7 +24,9 @@ namespace Supertext.Base.NetFramework.Configuration.Specs
             var config = container.Resolve<DummyConfig>();
 
             config.Value.Should().Be("any Value");
+            config.AnotherValue.Should().Be("another value");
             config.SomeInt.Should().Be(4711);
+            config.AnotherInt.Should().Be(9712);
             config.DoubleValue.Should().Be(0);
             config.ConnectionString.Should().Be("bla");
         }

--- a/Supertext.Base.NetFramework.Configuration.Specs/DummyConfig.cs
+++ b/Supertext.Base.NetFramework.Configuration.Specs/DummyConfig.cs
@@ -4,10 +4,15 @@ namespace Supertext.Base.NetFramework.Configuration.Specs
 {
     public class DummyConfig : IConfiguration
     {
+        public int AnotherInt { get; set; }
+
         public int SomeInt { get; set; }
 
         [SettingsKey("someString")]
         public string Value { get; set; }
+
+        [SettingsKey("AnotherString")]
+        public string AnotherValue { get; set; }
 
         public double DoubleValue { get; set; }
 

--- a/Supertext.Base.NetFramework.Configuration.Specs/app.config
+++ b/Supertext.Base.NetFramework.Configuration.Specs/app.config
@@ -1,10 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 
+  <configSections>
+    <section name="supertextConfiguration" type="Supertext.Base.NetFramework.Configuration.SupertextConfigurationSection, Supertext.Base.NetFramework.Configuration, Version=1.0.0.0, Culture=neutral" />
+  </configSections>
+
   <appSettings>
     <add key="SomeInt" value="4711" />
     <add key="someString" value="any Value" />
   </appSettings>
+
+  <supertextConfiguration>
+    <appSettings>
+      <add key="AnotherInt" value="9712" />
+      <add key="AnotherString" value="another value" />
+    </appSettings>
+  </supertextConfiguration>
 
   <connectionStrings>
     <add name="supertext" connectionString="bla" />

--- a/Supertext.Base.NetFramework.Configuration/AppSettings.cs
+++ b/Supertext.Base.NetFramework.Configuration/AppSettings.cs
@@ -1,0 +1,59 @@
+﻿using System.Configuration;
+
+namespace Supertext.Base.NetFramework.Configuration
+{
+    public class AppSettings : ConfigurationElementCollection
+    {
+        public Setting this[int index]
+        {
+            get => BaseGet(index) as Setting;
+            set
+            {
+                if (BaseGet(index) != null)
+                {
+                    BaseRemoveAt(index);
+                }
+
+                BaseAdd(index, value);
+            }
+        }
+
+        public new Setting this[string key]
+        {
+            get => (Setting) BaseGet(key);
+            set
+            {
+                if (BaseGet(key) != null)
+                {
+                    BaseRemoveAt(BaseIndexOf(BaseGet(key)));
+                }
+
+                BaseAdd(value);
+            }
+        }
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new Setting();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((Setting) element).Key;
+        }
+
+        public void Add(string key, string value)
+        {
+            BaseAdd(new Setting
+                        {
+                            Key = key,
+                            Value = value
+                        });
+        }
+
+        public void Remove(string key)
+        {
+            BaseRemove(key);
+        }
+    }
+}

--- a/Supertext.Base.NetFramework.Configuration/ConfigurationExtension.cs
+++ b/Supertext.Base.NetFramework.Configuration/ConfigurationExtension.cs
@@ -89,6 +89,12 @@ namespace Supertext.Base.NetFramework.Configuration
                 return Option<object>.Some(value);
             }
 
+            if (SupertextConfigurationManager.AppSettings.AllKeys.Any(key => key == settingsKey))
+            {
+                var value = SupertextConfigurationManager.AppSettings[settingsKey];
+                return Option<object>.Some(value);
+            }
+
             Console.WriteLine($"Key {settingsKey} not available");
             return Option<object>.None();
         }

--- a/Supertext.Base.NetFramework.Configuration/Setting.cs
+++ b/Supertext.Base.NetFramework.Configuration/Setting.cs
@@ -1,0 +1,21 @@
+﻿using System.Configuration;
+
+namespace Supertext.Base.NetFramework.Configuration
+{
+    public class Setting : ConfigurationElement
+    {
+        [ConfigurationProperty("key", IsRequired = true)]
+        public string Key
+        {
+            get => this["key"] as string;
+            set => this["key"] = value;
+        }
+
+        [ConfigurationProperty("value", IsRequired = true)]
+        public string Value
+        {
+            get => this["value"] as string;
+            set => this["value"] = value;
+        }
+    }
+}

--- a/Supertext.Base.NetFramework.Configuration/Supertext.Base.NetFramework.Configuration.csproj
+++ b/Supertext.Base.NetFramework.Configuration/Supertext.Base.NetFramework.Configuration.csproj
@@ -42,6 +42,9 @@
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Configuration.ConfigurationBuilders.Base, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Configuration.ConfigurationBuilders.Base.2.0.0\lib\Net471\Microsoft.Configuration.ConfigurationBuilders.Base.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -60,8 +63,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppSettings.cs" />
     <Compile Include="ConfigurationExtension.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Setting.cs" />
+    <Compile Include="SupertextConfigurationManager.cs" />
+    <Compile Include="SupertextConfigurationSection.cs" />
+    <Compile Include="SupertextConfigurationSectionHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Supertext.Base\Supertext.Base.csproj">

--- a/Supertext.Base.NetFramework.Configuration/SupertextConfigurationManager.cs
+++ b/Supertext.Base.NetFramework.Configuration/SupertextConfigurationManager.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Specialized;
+
+namespace Supertext.Base.NetFramework.Configuration
+{
+    public static class SupertextConfigurationManager
+    {
+        private static NameValueCollection _allSettings;
+
+        public static NameValueCollection AppSettings
+        {
+            get
+            {
+                if (_allSettings == null)
+                {
+                    var appSettings = SupertextConfigurationSection.GetConfig().AppSettings;
+                    var e = appSettings.GetEnumerator();
+                    _allSettings = new NameValueCollection(appSettings.Count);
+                    while (e.MoveNext())
+                    {
+                        if (e.Current is Setting setting)
+                        {
+                            _allSettings.Add(setting.Key, setting.Value);
+                        }
+                    }
+                }
+
+                return _allSettings;
+            }
+        }
+    }
+}

--- a/Supertext.Base.NetFramework.Configuration/SupertextConfigurationSection.cs
+++ b/Supertext.Base.NetFramework.Configuration/SupertextConfigurationSection.cs
@@ -1,0 +1,16 @@
+﻿using System.Configuration;
+
+namespace Supertext.Base.NetFramework.Configuration
+{
+    public class SupertextConfigurationSection : ConfigurationSection
+    {
+        public static SupertextConfigurationSection GetConfig()
+        {
+            return (SupertextConfigurationSection) ConfigurationManager.GetSection("supertextConfiguration") ?? new SupertextConfigurationSection();
+        }
+
+        [ConfigurationProperty("appSettings")]
+        [ConfigurationCollection(typeof(Setting), AddItemName = "add")]
+        public AppSettings AppSettings => this["appSettings"] as AppSettings;
+    }
+}

--- a/Supertext.Base.NetFramework.Configuration/SupertextConfigurationSectionHandler.cs
+++ b/Supertext.Base.NetFramework.Configuration/SupertextConfigurationSectionHandler.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Configuration.ConfigurationBuilders;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Supertext.Base.NetFramework.Configuration
+{
+    public class SupertextConfigurationSectionHandler : SectionHandler<SupertextConfigurationSection>
+    {
+        public override IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            return ConfigSection.AppSettings.OfType<Setting>()
+                                .Select(setting => new KeyValuePair<string, object>(setting.Key, setting.Value))
+                                .GetEnumerator();
+        }
+
+        public override void InsertOrUpdate(string newKey,
+                                            string newValue,
+                                            string oldKey = null,
+                                            object oldItem = null)
+        {
+            if (newValue == null)
+            {
+                return;
+            }
+
+            if (oldKey != null)
+            {
+                ConfigSection.AppSettings.Remove(oldKey);
+            }
+
+            ConfigSection.AppSettings.Remove(newKey);
+            ConfigSection.AppSettings.Add(newKey, newValue);
+        }
+    }
+}

--- a/Supertext.Base.NetFramework.Configuration/app.config
+++ b/Supertext.Base.NetFramework.Configuration/app.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <configSections>
+    <section name="configBuilders" type="System.Configuration.ConfigurationBuildersSection, System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" restartOnExternalChanges="false" requirePermission="false" />
+  </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/Supertext.Base.NetFramework.Configuration/packages.config
+++ b/Supertext.Base.NetFramework.Configuration/packages.config
@@ -3,6 +3,7 @@
   <package id="Autofac" version="5.1.2" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.Configuration.ConfigurationBuilders.Base" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="net472" developmentDependency="true" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />


### PR DESCRIPTION
We can now declare a `<supertextConfiguration>` section in config files, and Supertext.Base's `ConfigurationExtensions` will retrieve values as if they were in the standard `<appSettings>`. Furthermore, this `<supertextConfiguration>` section can also be populated by secrets,