### PR TITLE
Add IEventPublisher support to PublishEndpoint

### DIFF
--- a/Supertext.Base.Hosting/MassTransit/MessagingMassTransitModule.cs
+++ b/Supertext.Base.Hosting/MassTransit/MessagingMassTransitModule.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using MassTransit;
 using MassTransit.Transactions;
+using Supertext.Base.Events;
 using Supertext.Base.Messaging;
 
 namespace Supertext.Base.Hosting.MassTransit
@@ -9,7 +10,7 @@ namespace Supertext.Base.Hosting.MassTransit
     {
         protected override void Load(ContainerBuilder builder)
         {
-            builder.RegisterType<PublishEndpoint>().As<IMessagePublisher>();
+            builder.RegisterType<PublishEndpoint>().As<IMessagePublisher>().As<IEventPublisher>();
             builder.Register(context =>
                              {
                                  var bus = context.Resolve<IBusControl>();

--- a/Supertext.Base.Hosting/MassTransit/PublishEndpoint.cs
+++ b/Supertext.Base.Hosting/MassTransit/PublishEndpoint.cs
@@ -4,11 +4,12 @@ using System.Threading.Tasks;
 using MassTransit;
 using MassTransit.Transactions;
 using Microsoft.Extensions.Logging;
+using Supertext.Base.Events;
 using Supertext.Base.Messaging;
 
 namespace Supertext.Base.Hosting.MassTransit
 {
-    internal class PublishEndpoint : IMessagePublisher
+    internal class PublishEndpoint : IMessagePublisher, IEventPublisher
     {
         private readonly IPublishEndpoint _publishEndpoint;
         private readonly ITransactionalBus _transactionalBus;
@@ -25,25 +26,25 @@ namespace Supertext.Base.Hosting.MassTransit
 
         public Task PublishAsync<TMessage>(TMessage message, CancellationToken cancellationToken)
         {
-            _logger.LogDebug($"Sending message of type {typeof(TMessage).Name}.");
+            _logger.LogDebug($"Sending message/event of type {typeof(TMessage).Name}.");
             return PublishAsync(message, Guid.NewGuid(), cancellationToken);
         }
 
         public Task PublishAsync<TMessage>(TMessage message, Guid correlationId, CancellationToken cancellationToken)
         {
-            _logger.LogDebug($"Sending message of type {typeof(TMessage).Name} with correlation ID {correlationId}.");
+            _logger.LogDebug($"Sending message/event of type {typeof(TMessage).Name} with correlation ID {correlationId}.");
             return _publishEndpoint.Publish(message, context => context.CorrelationId = correlationId, cancellationToken);
         }
 
         public Task PublishWithinTransactionScopeAsync<TMessage>(TMessage message, CancellationToken cancellationToken)
         {
-            _logger.LogDebug($"Sending message of type {typeof(TMessage).Name}.");
+            _logger.LogDebug($"Sending message/event of type {typeof(TMessage).Name}.");
             return PublishWithinTransactionScopeAsync(message, Guid.NewGuid(), cancellationToken);
         }
 
         public Task PublishWithinTransactionScopeAsync<TMessage>(TMessage message, Guid correlationId, CancellationToken cancellationToken)
         {
-            _logger.LogDebug($"Sending message of type {typeof(TMessage).Name} with correlation ID {correlationId}.");
+            _logger.LogDebug($"Sending message/event of type {typeof(TMessage).Name} with correlation ID {correlationId}.");
             return _transactionalBus.Publish(message, context => context.CorrelationId = correlationId, cancellationToken);
         }
     }

--- a/Supertext.Base/Events/IEventPublisher.cs
+++ b/Supertext.Base/Events/IEventPublisher.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Supertext.Base.Events;
+
+public interface IEventPublisher
+{
+    Task PublishAsync<TEvent>(TEvent payload, CancellationToken ct);
+    Task PublishAsync<TEvent>(TEvent payload, Guid correlationId, CancellationToken ct);
+
+    Task PublishWithinTransactionScopeAsync<TEvent>(TEvent payload, CancellationToken ct);
+    Task PublishWithinTransactionScopeAsync<TEvent>(TEvent payload, Guid correlationId, CancellationToken ct);
+}


### PR DESCRIPTION
- Register PublishEndpoint as IMessagePublisher and IEventPublisher in MessagingMassTransitModule
- Implement IEventPublisher in PublishEndpoint
- Update log messages in PublishEndpoint to reflect handling of messages/events
- Add IEventPublisher interface with event publishing methods