### PR TITLE
Refactor Correlation ID handling in middleware tests

### DIFF
--- a/Supertext.Base.Hosting.Specs/Middleware/CorrelationIdMiddlewareTest.cs
+++ b/Supertext.Base.Hosting.Specs/Middleware/CorrelationIdMiddlewareTest.cs
@@ -53,13 +53,26 @@ namespace Supertext.Base.Hosting.Specs.Middleware
         }
 
         [TestMethod]
+        public async Task Get_InvokedWithCorrelationIdInHeaderNotReformatted_ItIsUsed()
+        {
+            const string correlationId = "B6B03A9F-2D0E-4BA4-A47D-FFFC38AB1079";
+            _testee!.DefaultRequestHeaders.Add(CorrelationIdHeader, correlationId);
+
+            var response = await _testee!.GetAsync("/api/test/4711");
+
+            var result = await response.Content.ReadAsStringAsync();
+
+            result.Should().Be(Guid.Parse(correlationId).ToString());
+        }
+
+        [TestMethod]
         public async Task GetAsync_InvokedWithoutCorrelationIdInHeader_CorrelationIdIsInResponseHeader()
         {
             var response = await _testee!.GetAsync("/api/test/4711");
 
             var correlationId = response.Headers.GetValues(CorrelationIdHeader).Single();
 
-            correlationId.Should().Be(Guid.Parse(Startup.Guid).ToString("N").ToLowerInvariant());
+            correlationId.Should().Be(Guid.Parse(Startup.Guid).ToString().ToLowerInvariant());
         }
     }
 }

--- a/Supertext.Base.Hosting/Middleware/CorrelationIdMiddleware.cs
+++ b/Supertext.Base.Hosting/Middleware/CorrelationIdMiddleware.cs
@@ -10,7 +10,6 @@ namespace Supertext.Base.Hosting.Middleware;
 
 public class CorrelationIdMiddleware
 {
-    private const string GuidDigitsFormat = "N";
     private static readonly string DefaultCorrelationId = Guid.Empty.ToString();
     private static readonly string DefaultCorrelationIdDigitsOnly = DefaultCorrelationId.Replace("-", "");
     private readonly RequestDelegate _next;
@@ -50,7 +49,7 @@ public class CorrelationIdMiddleware
         }
         else
         {
-            var newCorrelationId = _guidFactory.Create().ToString(GuidDigitsFormat);
+            var newCorrelationId = _guidFactory.Create().ToString();
             context.TraceIdentifier = newCorrelationId;
             context.Request.Headers.Remove(_options.Header);
             context.Request.Headers.Append(_options.Header, new StringValues(newCorrelationId));


### PR DESCRIPTION
Introduce a new test to ensure correlation ID is used as-is when present in the header. Modify an existing test to check the correlation ID in the response header using the default ToString() method. Remove GuidDigitsFormat constant and update code to use default ToString() method for generating new correlation IDs.