### PR TITLE
Extend SqlResultConverter to interpret UTC dates of objects #14205

### DIFF
--- a/Supertext.Base.Dal.SqlServer.Tests/Utils/SqlResultConverterTest.cs
+++ b/Supertext.Base.Dal.SqlServer.Tests/Utils/SqlResultConverterTest.cs
@@ -171,7 +171,7 @@ public class SqlResultConverterTest
     {
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.Now,
+                                      DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
                                       null);
 
         var converter = new SqlResultConverter();
@@ -180,7 +180,7 @@ public class SqlResultConverterTest
         results.Id.Should().Be(testData.Id);
         results.Name.Should().Be(testData.Name);
         results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
-        results.UpdatedOn.Should().Be(testData.UpdatedOn);
+        results.UpdatedOn.Should().BeNull();
     }
 
     [TestMethod]
@@ -188,15 +188,12 @@ public class SqlResultConverterTest
     {
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.Now.AddDays(-2),
-                                      DateTime.Now);
+                                      DateTime.SpecifyKind(DateTime.Now.AddDays(-2), DateTimeKind.Local),
+                                      DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local));
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
 
-        results.Id.Should().Be(testData.Id);
-        results.Name.Should().Be(testData.Name);
-        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
         results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
     }
 
@@ -205,22 +202,18 @@ public class SqlResultConverterTest
     {
         var nestedObject = new TestEntity(Guid.NewGuid(),
                                           "Nested",
-                                          DateTime.Now,
+                                          DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
                                           null);
 
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.Now.AddDays(-2),
-                                      DateTime.Now,
+                                      DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
+                                      null,
                                       nestedObject);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
 
-        results.Id.Should().Be(testData.Id);
-        results.Name.Should().Be(testData.Name);
-        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
-        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
         results.NestedObject!.Id.Should().Be(nestedObject.Id);
         results.NestedObject.Name.Should().Be(nestedObject.Name);
         results.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
@@ -231,28 +224,25 @@ public class SqlResultConverterTest
     {
         var nestedObject1 = new TestEntity(Guid.NewGuid(),
                                           "Nested 1",
-                                          DateTime.Now,
+                                          DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
                                           null);
 
         var nestedObject2 = new TestEntity(Guid.NewGuid(),
                                            "Nested 2",
-                                           DateTime.Now.AddDays(-5),
-                                           DateTime.Now,
+                                           DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                           DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
                                            nestedObject1);
 
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.Now.AddDays(-2),
-                                      DateTime.Now,
+                                      DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                      null,
                                       nestedObject2);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
 
-        results.Id.Should().Be(testData.Id);
-        results.Name.Should().Be(testData.Name);
-        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
-        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+
         results.NestedObject!.Id.Should().Be(nestedObject2.Id);
         results.NestedObject.Name.Should().Be(nestedObject2.Name);
         results.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
@@ -267,27 +257,23 @@ public class SqlResultConverterTest
     {
         var item1 = new TestEntity(Guid.NewGuid(),
                                            "Item 1",
-                                           DateTime.Now,
+                                           DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
                                            null);
 
         var item2 = new TestEntity(Guid.NewGuid(),
                                            "Item 2",
-                                           DateTime.Now.AddDays(-5),
-                                           DateTime.Now);
+                                           DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                           DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local));
 
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.Now.AddDays(-2),
-                                      DateTime.Now,
+                                      DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                      null,
                                       NestedCollection: [item1, item2]);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
 
-        results.Id.Should().Be(testData.Id);
-        results.Name.Should().Be(testData.Name);
-        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
-        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
         results.NestedCollection!.Count.Should().Be(2);
         results.NestedCollection[0].Id.Should().Be(item1.Id);
         results.NestedCollection[0].Name.Should().Be(item1.Name);
@@ -303,33 +289,25 @@ public class SqlResultConverterTest
     {
         var nestedObject = new TestEntity(Guid.NewGuid(),
                                            "Nested",
-                                           DateTime.Now,
+                                           DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
                                            null);
 
         var item = new TestEntity(Guid.NewGuid(),
                                            "Item",
-                                           DateTime.Now.AddDays(-5),
-                                           DateTime.Now,
+                                           DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                           null,
                                            nestedObject);
 
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.Now.AddDays(-2),
-                                      DateTime.Now,
+                                      DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                      null,
                                       NestedCollection: [item]);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
 
-        results.Id.Should().Be(testData.Id);
-        results.Name.Should().Be(testData.Name);
-        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
-        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
         results.NestedCollection!.Count.Should().Be(1);
-        results.NestedCollection[0].Id.Should().Be(item.Id);
-        results.NestedCollection[0].Name.Should().Be(item.Name);
-        results.NestedCollection[0].CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
-        results.NestedCollection[0].UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
         results.NestedCollection[0].NestedObject!.Id.Should().Be(nestedObject.Id);
         results.NestedCollection[0].NestedObject!.Name.Should().Be(nestedObject.Name);
         results.NestedCollection[0].NestedObject!.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);

--- a/Supertext.Base.Dal.SqlServer.Tests/Utils/SqlResultConverterTest.cs
+++ b/Supertext.Base.Dal.SqlServer.Tests/Utils/SqlResultConverterTest.cs
@@ -171,8 +171,10 @@ public class SqlResultConverterTest
     {
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
+                                      DateTime.Now,
                                       null);
+
+        testData.CreatedOn.Kind.Should().Be(DateTimeKind.Local);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
@@ -188,8 +190,10 @@ public class SqlResultConverterTest
     {
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.SpecifyKind(DateTime.Now.AddDays(-2), DateTimeKind.Local),
-                                      DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local));
+                                      DateTime.Now.AddDays(-2),
+                                      DateTime.Now);
+
+        testData.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Local);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
@@ -202,14 +206,16 @@ public class SqlResultConverterTest
     {
         var nestedObject = new TestEntity(Guid.NewGuid(),
                                           "Nested",
-                                          DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
+                                          DateTime.Now,
                                           null);
 
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
+                                      DateTime.Now,
                                       null,
                                       nestedObject);
+
+        testData.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Local);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
@@ -224,29 +230,26 @@ public class SqlResultConverterTest
     {
         var nestedObject1 = new TestEntity(Guid.NewGuid(),
                                           "Nested 1",
-                                          DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
+                                          DateTime.Now,
                                           null);
 
         var nestedObject2 = new TestEntity(Guid.NewGuid(),
                                            "Nested 2",
-                                           DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
-                                           DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
+                                           DateTime.Now.AddDays(-5),
+                                           DateTime.Now,
                                            nestedObject1);
 
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                      DateTime.Now.AddDays(-5),
                                       null,
                                       nestedObject2);
+
+        testData.NestedObject.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Local);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
 
-
-        results.NestedObject!.Id.Should().Be(nestedObject2.Id);
-        results.NestedObject.Name.Should().Be(nestedObject2.Name);
-        results.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
-        results.NestedObject.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
         results.NestedObject!.NestedObject!.Id.Should().Be(nestedObject1.Id);
         results.NestedObject.NestedObject.Name.Should().Be(nestedObject1.Name);
         results.NestedObject.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
@@ -257,19 +260,23 @@ public class SqlResultConverterTest
     {
         var item1 = new TestEntity(Guid.NewGuid(),
                                            "Item 1",
-                                           DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
+                                           DateTime.Now,
                                            null);
 
         var item2 = new TestEntity(Guid.NewGuid(),
                                            "Item 2",
-                                           DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
-                                           DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local));
+                                           DateTime.Now.AddDays(-5),
+                                           DateTime.Now);
 
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                      DateTime.Now.AddDays(-5),
                                       null,
                                       NestedCollection: [item1, item2]);
+
+        testData.NestedCollection[0].CreatedOn.Kind.Should().Be(DateTimeKind.Local);
+        testData.NestedCollection[1].CreatedOn.Kind.Should().Be(DateTimeKind.Local);
+        testData.NestedCollection[1].UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Local);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);
@@ -289,20 +296,22 @@ public class SqlResultConverterTest
     {
         var nestedObject = new TestEntity(Guid.NewGuid(),
                                            "Nested",
-                                           DateTime.SpecifyKind(DateTime.Now, DateTimeKind.Local),
+                                           DateTime.Now,
                                            null);
 
         var item = new TestEntity(Guid.NewGuid(),
                                            "Item",
-                                           DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                           DateTime.Now.AddDays(-5),
                                            null,
                                            nestedObject);
 
         var testData = new TestEntity(Guid.NewGuid(),
                                       "Test",
-                                      DateTime.SpecifyKind(DateTime.Now.AddDays(-5), DateTimeKind.Local),
+                                      DateTime.Now.AddDays(-5),
                                       null,
                                       NestedCollection: [item]);
+
+        testData.NestedCollection[0].NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Local);
 
         var converter = new SqlResultConverter();
         var results = converter.InterpretUtcDates(testData);

--- a/Supertext.Base.Dal.SqlServer.Tests/Utils/SqlResultConverterTest.cs
+++ b/Supertext.Base.Dal.SqlServer.Tests/Utils/SqlResultConverterTest.cs
@@ -165,4 +165,180 @@ public class SqlResultConverterTest
         (b.GetProperty("c1").GetInt32()).Should().Be(1);
         (b.GetProperty("c2").GetInt32()).Should().Be(2);
     }
+
+    [TestMethod]
+    public void InterpretUtcDates_ObjectWithNonNullableDateTime_ConvertedInUtc()
+    {
+        var testData = new TestEntity(Guid.NewGuid(),
+                                      "Test",
+                                      DateTime.Now,
+                                      null);
+
+        var converter = new SqlResultConverter();
+        var results = converter.InterpretUtcDates(testData);
+
+        results.Id.Should().Be(testData.Id);
+        results.Name.Should().Be(testData.Name);
+        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.UpdatedOn.Should().Be(testData.UpdatedOn);
+    }
+
+    [TestMethod]
+    public void InterpretUtcDates_ObjectWithNullableDateTime_ConvertedInUtc()
+    {
+        var testData = new TestEntity(Guid.NewGuid(),
+                                      "Test",
+                                      DateTime.Now.AddDays(-2),
+                                      DateTime.Now);
+
+        var converter = new SqlResultConverter();
+        var results = converter.InterpretUtcDates(testData);
+
+        results.Id.Should().Be(testData.Id);
+        results.Name.Should().Be(testData.Name);
+        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [TestMethod]
+    public void InterpretUtcDates_ObjectWithNestedObject_ConvertedInUtc()
+    {
+        var nestedObject = new TestEntity(Guid.NewGuid(),
+                                          "Nested",
+                                          DateTime.Now,
+                                          null);
+
+        var testData = new TestEntity(Guid.NewGuid(),
+                                      "Test",
+                                      DateTime.Now.AddDays(-2),
+                                      DateTime.Now,
+                                      nestedObject);
+
+        var converter = new SqlResultConverter();
+        var results = converter.InterpretUtcDates(testData);
+
+        results.Id.Should().Be(testData.Id);
+        results.Name.Should().Be(testData.Name);
+        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedObject!.Id.Should().Be(nestedObject.Id);
+        results.NestedObject.Name.Should().Be(nestedObject.Name);
+        results.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [TestMethod]
+    public void InterpretUtcDates_ObjectWithMultipleNestedObject_ConvertedInUtc()
+    {
+        var nestedObject1 = new TestEntity(Guid.NewGuid(),
+                                          "Nested 1",
+                                          DateTime.Now,
+                                          null);
+
+        var nestedObject2 = new TestEntity(Guid.NewGuid(),
+                                           "Nested 2",
+                                           DateTime.Now.AddDays(-5),
+                                           DateTime.Now,
+                                           nestedObject1);
+
+        var testData = new TestEntity(Guid.NewGuid(),
+                                      "Test",
+                                      DateTime.Now.AddDays(-2),
+                                      DateTime.Now,
+                                      nestedObject2);
+
+        var converter = new SqlResultConverter();
+        var results = converter.InterpretUtcDates(testData);
+
+        results.Id.Should().Be(testData.Id);
+        results.Name.Should().Be(testData.Name);
+        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedObject!.Id.Should().Be(nestedObject2.Id);
+        results.NestedObject.Name.Should().Be(nestedObject2.Name);
+        results.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedObject.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedObject!.NestedObject!.Id.Should().Be(nestedObject1.Id);
+        results.NestedObject.NestedObject.Name.Should().Be(nestedObject1.Name);
+        results.NestedObject.NestedObject.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [TestMethod]
+    public void InterpretUtcDates_ObjectWithCollection_ConvertedInUtc()
+    {
+        var item1 = new TestEntity(Guid.NewGuid(),
+                                           "Item 1",
+                                           DateTime.Now,
+                                           null);
+
+        var item2 = new TestEntity(Guid.NewGuid(),
+                                           "Item 2",
+                                           DateTime.Now.AddDays(-5),
+                                           DateTime.Now);
+
+        var testData = new TestEntity(Guid.NewGuid(),
+                                      "Test",
+                                      DateTime.Now.AddDays(-2),
+                                      DateTime.Now,
+                                      NestedCollection: [item1, item2]);
+
+        var converter = new SqlResultConverter();
+        var results = converter.InterpretUtcDates(testData);
+
+        results.Id.Should().Be(testData.Id);
+        results.Name.Should().Be(testData.Name);
+        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedCollection!.Count.Should().Be(2);
+        results.NestedCollection[0].Id.Should().Be(item1.Id);
+        results.NestedCollection[0].Name.Should().Be(item1.Name);
+        results.NestedCollection[0].CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedCollection[1].Id.Should().Be(item2.Id);
+        results.NestedCollection[1].Name.Should().Be(item2.Name);
+        results.NestedCollection[1].CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedCollection[1].UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [TestMethod]
+    public void InterpretUtcDates_ObjectWithCollectionThatHasNestedObject_ConvertedInUtc()
+    {
+        var nestedObject = new TestEntity(Guid.NewGuid(),
+                                           "Nested",
+                                           DateTime.Now,
+                                           null);
+
+        var item = new TestEntity(Guid.NewGuid(),
+                                           "Item",
+                                           DateTime.Now.AddDays(-5),
+                                           DateTime.Now,
+                                           nestedObject);
+
+        var testData = new TestEntity(Guid.NewGuid(),
+                                      "Test",
+                                      DateTime.Now.AddDays(-2),
+                                      DateTime.Now,
+                                      NestedCollection: [item]);
+
+        var converter = new SqlResultConverter();
+        var results = converter.InterpretUtcDates(testData);
+
+        results.Id.Should().Be(testData.Id);
+        results.Name.Should().Be(testData.Name);
+        results.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedCollection!.Count.Should().Be(1);
+        results.NestedCollection[0].Id.Should().Be(item.Id);
+        results.NestedCollection[0].Name.Should().Be(item.Name);
+        results.NestedCollection[0].CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedCollection[0].UpdatedOn!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        results.NestedCollection[0].NestedObject!.Id.Should().Be(nestedObject.Id);
+        results.NestedCollection[0].NestedObject!.Name.Should().Be(nestedObject.Name);
+        results.NestedCollection[0].NestedObject!.CreatedOn.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    private record TestEntity(Guid Id,
+                              string Name,
+                              DateTime CreatedOn,
+                              DateTime? UpdatedOn,
+                              TestEntity NestedObject = null,
+                              IList<TestEntity> NestedCollection = null);
 }

--- a/Supertext.Base.Dal.SqlServer/Utils/SqlResultConverter.cs
+++ b/Supertext.Base.Dal.SqlServer/Utils/SqlResultConverter.cs
@@ -9,9 +9,19 @@ namespace Supertext.Base.Dal.SqlServer.Utils
 {
     public class SqlResultConverter : ISqlResultConverter
     {
-        public IDictionary<string, object> InterpretUtcDates(IDictionary<string, object> row)
+        public TEntity InterpretUtcDates<TEntity>(TEntity entity) where TEntity : class
         {
-            return InterpretDictionaryUtcDates(row);
+            if (entity == null)
+            {
+                return null;
+            }
+
+            if (entity is IDictionary<string, object> dictionary)
+            {
+                return InterpretDictionaryUtcDates(dictionary) as TEntity;
+            }
+
+            return InterpretUtcDatesRecursive(entity);
         }
 
         public IDictionary<string, object> DecodeStructure(IDictionary<string, object> row)
@@ -55,21 +65,6 @@ namespace Supertext.Base.Dal.SqlServer.Utils
                 }
             }
             return result;
-        }
-
-        public TEntity InterpretUtcDates<TEntity>(TEntity entity) where TEntity : class
-        {
-            if (entity == null)
-            {
-                return null;
-            }
-
-            if (entity is IDictionary<string, object> dictionary)
-            {
-                return InterpretDictionaryUtcDates(dictionary) as TEntity;
-            }
-
-            return InterpretUtcDatesRecursive(entity);
         }
 
         private IDictionary<string, object> InterpretDictionaryUtcDates(IDictionary<string, object> row)

--- a/Supertext.Base.Dal.SqlServer/Utils/SqlResultConverter.cs
+++ b/Supertext.Base.Dal.SqlServer/Utils/SqlResultConverter.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 
 namespace Supertext.Base.Dal.SqlServer.Utils
@@ -9,9 +11,7 @@ namespace Supertext.Base.Dal.SqlServer.Utils
     {
         public IDictionary<string, object> InterpretUtcDates(IDictionary<string, object> row)
         {
-            return row.ToDictionary(
-                field => field.Key,
-                field => field.Value is DateTime date ? DateTime.SpecifyKind(date, DateTimeKind.Utc) : field.Value);
+            return InterpretDictionaryUtcDates(row);
         }
 
         public IDictionary<string, object> DecodeStructure(IDictionary<string, object> row)
@@ -57,5 +57,90 @@ namespace Supertext.Base.Dal.SqlServer.Utils
             return result;
         }
 
+        public TEntity InterpretUtcDates<TEntity>(TEntity entity) where TEntity : class
+        {
+            if (entity == null)
+            {
+                return null;
+            }
+
+            if (entity is IDictionary<string, object> dictionary)
+            {
+                return InterpretDictionaryUtcDates(dictionary) as TEntity;
+            }
+
+            return InterpretUtcDatesRecursive(entity);
+        }
+
+        private IDictionary<string, object> InterpretDictionaryUtcDates(IDictionary<string, object> row)
+        {
+            return row.ToDictionary(field => field.Key,
+                                    field => field.Value is DateTime date ? DateTime.SpecifyKind(date, DateTimeKind.Utc) : field.Value);
+        }
+
+        private TEntity InterpretUtcDatesRecursive<TEntity>(TEntity entity) where TEntity : class
+        {
+            var properties = entity.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var property in properties)
+            {
+                if (property.PropertyType == typeof(DateTime) || property.PropertyType == typeof(DateTime?))
+                {
+                    ProcessDateTimeProperty(property, entity);
+                }
+                else if (property.PropertyType.IsClass && property.PropertyType != typeof(string))
+                {
+                    var nestedObject = property.GetValue(entity);
+                    if (nestedObject != null)
+                    {
+                        var updatedNestedObject = InterpretUtcDatesRecursive(nestedObject);
+                        property.SetValue(entity, updatedNestedObject);
+                    }
+                }
+                else if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType) && property.PropertyType != typeof(string))
+                {
+                    if (property.GetValue(entity) is IEnumerable collection)
+                    {
+                        foreach (var item in collection)
+                        {
+                            if (item is DateTime)
+                            {
+                                ProcessDateTimeProperty(property, entity);
+                            }
+                            else if (item != null && item.GetType().IsClass && item.GetType() != typeof(string))
+                            {
+                                InterpretUtcDatesRecursive(item);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return entity;
+        }
+
+        private void ProcessDateTimeProperty<TEntity>(PropertyInfo property, TEntity entity)
+        {
+            var currentValue = property.GetValue(entity);
+
+            if (currentValue != null && property.PropertyType == typeof(DateTime))
+            {
+                var dateTime = (DateTime)currentValue;
+                if (dateTime.Kind != DateTimeKind.Utc)
+                {
+                    var utcValue = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+                    property.SetValue(entity, utcValue);
+                }
+            }
+            else if (property.PropertyType == typeof(DateTime?))
+            {
+                var nullableDateTime = (DateTime?)currentValue;
+                if (nullableDateTime.HasValue && nullableDateTime.Value.Kind != DateTimeKind.Utc)
+                {
+                    var utcValue = DateTime.SpecifyKind(nullableDateTime.Value, DateTimeKind.Utc);
+                    property.SetValue(entity, utcValue);
+                }
+            }
+        }
     }
 }

--- a/Supertext.Base/Dal/ISqlResultConverter.cs
+++ b/Supertext.Base/Dal/ISqlResultConverter.cs
@@ -4,7 +4,6 @@ namespace Supertext.Base.Dal
 {
     public interface ISqlResultConverter
     {
-        IDictionary<string, object> InterpretUtcDates(IDictionary<string, object> row);
         TEntity InterpretUtcDates<TEntity>(TEntity entity) where TEntity : class;
         IDictionary<string, object> DecodeStructure(IDictionary<string, object> row);
     }

--- a/Supertext.Base/Dal/ISqlResultConverter.cs
+++ b/Supertext.Base/Dal/ISqlResultConverter.cs
@@ -5,6 +5,7 @@ namespace Supertext.Base.Dal
     public interface ISqlResultConverter
     {
         IDictionary<string, object> InterpretUtcDates(IDictionary<string, object> row);
+        TEntity InterpretUtcDates<TEntity>(TEntity entity) where TEntity : class;
         IDictionary<string, object> DecodeStructure(IDictionary<string, object> row);
     }
 }


### PR DESCRIPTION
Updated SqlResultConverter with InterpretUtcDates method to convert DateTime properties to UTC, including nested objects and collections. Added new tests in SqlResultConverterTest to validate this functionality. Updated ISqlResultConverter interface accordingly.